### PR TITLE
feat(refreshtoken): 리프레시 토큰 도메인 추가

### DIFF
--- a/src/main/java/lang/studyhub/domain/refreshtoken/controller/RefreshTokenController.java
+++ b/src/main/java/lang/studyhub/domain/refreshtoken/controller/RefreshTokenController.java
@@ -1,0 +1,59 @@
+package lang.studyhub.domain.refreshtoken.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lang.studyhub.domain.refreshtoken.dto.*;
+import lang.studyhub.domain.refreshtoken.dto.IssueRefreshTokenRequest;
+import lang.studyhub.domain.refreshtoken.dto.TokenResponse;
+import lang.studyhub.domain.refreshtoken.service.RefreshTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "RefreshTokens", description="토큰 API")
+@RestController
+@RequestMapping("/api/auth/refresh-tokens")
+@RequiredArgsConstructor
+public class RefreshTokenController {
+
+    private final RefreshTokenService refreshTokenService;
+
+    // 임시: X-USER-ID 헤더에서 사용자 추출 (보안 붙이면 Principal 사용)
+    private Long currentUserId(String header) {
+        if (header == null || header.isBlank()) throw new IllegalArgumentException("X-USER-ID header required");
+        return Long.parseLong(header);
+    }
+
+    @PostMapping
+    public ResponseEntity<TokenResponse> issue(
+            @RequestHeader("X-USER-ID") String userIdHeader,
+            @Valid @RequestBody(required = false) IssueRefreshTokenRequest request
+    ) {
+        Long userId = currentUserId(userIdHeader);
+        return ResponseEntity.ok(refreshTokenService.issue(userId, request));
+    }
+
+    @PostMapping("/rotate")
+    public ResponseEntity<TokenResponse> rotate(
+            @Valid @RequestBody RotateRefreshTokenRequest request
+    ) {
+        return ResponseEntity.ok(refreshTokenService.rotate(request));
+    }
+
+    @GetMapping("/{token}")
+    public ResponseEntity<ValidateTokenResponse> validate(@PathVariable String token) {
+        return ResponseEntity.ok(refreshTokenService.validate(token));
+    }
+
+    @DeleteMapping("/{token}")
+    public ResponseEntity<Void> revoke(@PathVariable String token) {
+        refreshTokenService.revoke(token);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/users/{userId}")
+    public ResponseEntity<Void> revokeAllByUser(@PathVariable Long userId) {
+        refreshTokenService.revokeAllByUser(userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/lang/studyhub/domain/refreshtoken/dto/IssueRefreshTokenRequest.java
+++ b/src/main/java/lang/studyhub/domain/refreshtoken/dto/IssueRefreshTokenRequest.java
@@ -1,0 +1,5 @@
+package lang.studyhub.domain.refreshtoken.dto;
+
+public record IssueRefreshTokenRequest(
+        Long ttlSeconds // null이면 기본값 사용(14일)
+) {}

--- a/src/main/java/lang/studyhub/domain/refreshtoken/dto/RotateRefreshTokenRequest.java
+++ b/src/main/java/lang/studyhub/domain/refreshtoken/dto/RotateRefreshTokenRequest.java
@@ -1,0 +1,6 @@
+package lang.studyhub.domain.refreshtoken.dto;
+
+public record RotateRefreshTokenRequest(
+        String oldToken,
+        Long ttlSeconds // null이면 기본값 사용(14일)
+) {}

--- a/src/main/java/lang/studyhub/domain/refreshtoken/dto/TokenResponse.java
+++ b/src/main/java/lang/studyhub/domain/refreshtoken/dto/TokenResponse.java
@@ -1,0 +1,8 @@
+package lang.studyhub.domain.refreshtoken.dto;
+
+import java.time.Instant;
+
+public record TokenResponse(
+        String token,
+        Instant expiresAt
+) {}

--- a/src/main/java/lang/studyhub/domain/refreshtoken/dto/ValidateTokenResponse.java
+++ b/src/main/java/lang/studyhub/domain/refreshtoken/dto/ValidateTokenResponse.java
@@ -1,0 +1,8 @@
+package lang.studyhub.domain.refreshtoken.dto;
+
+import java.time.Instant;
+
+public record ValidateTokenResponse(
+        boolean valid,
+        Instant expiresAt
+) {}

--- a/src/main/java/lang/studyhub/domain/refreshtoken/entity/RefreshToken.java
+++ b/src/main/java/lang/studyhub/domain/refreshtoken/entity/RefreshToken.java
@@ -1,0 +1,31 @@
+package lang.studyhub.domain.refreshtoken.entity;
+
+import jakarta.persistence.*;
+import lang.studyhub.domain.user.entity.User;
+import lombok.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "refreshtoken")
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class RefreshToken {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch=FetchType.LAZY, optional=false)
+    @JoinColumn(name="user_id", nullable=false)
+    private User user;
+
+    @Column(nullable=false, unique=true, length=512)
+    private String token;
+
+    @Column(name="expires_at", nullable=false)
+    private Instant expiresAt;
+
+    @Column(name="created_at", nullable=false, updatable=false)
+    private Instant createdAt;
+
+    @PrePersist
+    void onCreate() { createdAt = Instant.now(); }
+}

--- a/src/main/java/lang/studyhub/domain/refreshtoken/repository/RefreshTokenRepository.java
+++ b/src/main/java/lang/studyhub/domain/refreshtoken/repository/RefreshTokenRepository.java
@@ -1,0 +1,14 @@
+package lang.studyhub.domain.refreshtoken.repository;
+
+
+import lang.studyhub.domain.refreshtoken.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+    boolean existsByToken(String token);
+    long deleteByToken(String token);
+    long deleteByUserId(Long userId);
+}

--- a/src/main/java/lang/studyhub/domain/refreshtoken/service/RefreshTokenService.java
+++ b/src/main/java/lang/studyhub/domain/refreshtoken/service/RefreshTokenService.java
@@ -1,0 +1,94 @@
+package lang.studyhub.domain.refreshtoken.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lang.studyhub.domain.refreshtoken.dto.*;
+import lang.studyhub.domain.refreshtoken.entity.RefreshToken;
+import lang.studyhub.domain.refreshtoken.repository.RefreshTokenRepository;
+import lang.studyhub.domain.user.entity.User;
+import lang.studyhub.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RefreshTokenService {
+
+    private static final long DEFAULT_TTL_SECONDS = 60L * 60L * 24L * 14L; // 14 days
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public TokenResponse issue(Long userId, IssueRefreshTokenRequest req) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found: " + userId));
+
+        long ttl = req != null && req.ttlSeconds() != null ? req.ttlSeconds() : DEFAULT_TTL_SECONDS;
+        Instant expiresAt = Instant.now().plusSeconds(ttl);
+
+        String token = UUID.randomUUID().toString();
+
+        RefreshToken saved = refreshTokenRepository.save(
+                RefreshToken.builder()
+                        .user(user)
+                        .token(token)
+                        .expiresAt(expiresAt)
+                        .build()
+        );
+        return new TokenResponse(saved.getToken(), saved.getExpiresAt());
+    }
+
+    @Transactional
+    public TokenResponse rotate(RotateRefreshTokenRequest req) {
+        if (req == null || req.oldToken() == null || req.oldToken().isBlank()) {
+            throw new IllegalArgumentException("oldToken is required");
+        }
+
+        RefreshToken old = refreshTokenRepository.findByToken(req.oldToken())
+                .orElseThrow(() -> new EntityNotFoundException("Refresh token not found"));
+
+        // (선택) 만료된 토큰이면 거부
+        if (old.getExpiresAt().isBefore(Instant.now())) {
+            // 만료 토큰은 삭제
+            refreshTokenRepository.delete(old);
+            throw new IllegalStateException("Refresh token expired");
+        }
+
+        long ttl = (req.ttlSeconds() != null) ? req.ttlSeconds() : DEFAULT_TTL_SECONDS;
+        Instant expiresAt = Instant.now().plusSeconds(ttl);
+        String newToken = UUID.randomUUID().toString();
+
+        // 회전: 기존 토큰 삭제 후 새 토큰 발급
+        refreshTokenRepository.delete(old);
+
+        RefreshToken saved = refreshTokenRepository.save(
+                RefreshToken.builder()
+                        .user(old.getUser())
+                        .token(newToken)
+                        .expiresAt(expiresAt)
+                        .build()
+        );
+        return new TokenResponse(saved.getToken(), saved.getExpiresAt());
+    }
+
+    public ValidateTokenResponse validate(String token) {
+        return refreshTokenRepository.findByToken(token)
+                .map(rt -> new ValidateTokenResponse(rt.getExpiresAt().isAfter(Instant.now()), rt.getExpiresAt()))
+                .orElseGet(() -> new ValidateTokenResponse(false, null));
+    }
+
+    @Transactional
+    public void revoke(String token) {
+        refreshTokenRepository.deleteByToken(token);
+    }
+
+    @Transactional
+    public void revokeAllByUser(Long userId) {
+        refreshTokenRepository.deleteByUserId(userId);
+    }
+}


### PR DESCRIPTION
- RefreshToken 엔티티 및 Repository 추가
- RefreshTokenService: 발급(issue), 회전(rotate), 검증(validate), 폐기(revoke), 사용자 전체 토큰 삭제 구현
- RefreshTokenController: /api/auth/refresh-tokens 엔드포인트 (POST 발급, POST /rotate, GET /{token}, DELETE /{token}, DELETE /users/{userId})
- DTO: IssueRefreshTokenRequest, RotateRefreshTokenRequest, TokenResponse, ValidateTokenResponse
- Swagger 문서 태그 @Tag("RefreshTokens") 적용
- 기본 TTL 14일, UUID 기반 토큰 발급 (임시)